### PR TITLE
[ADD-476] Added possibility to pass custom query params.

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -20,6 +20,11 @@ class Client extends \GuzzleHttp\Client
      * @var array
      */
     private $filter;
+    
+    /**
+     * @var array
+     */
+    private $queryParams;
 
     /**
      * @inheritdoc
@@ -81,6 +86,22 @@ class Client extends \GuzzleHttp\Client
 
         return $this;
     }
+    
+    /**
+     * @param string $key
+     * @param $values
+     * @return Client
+     */
+    public function addQueryParam(string $key, $values): Client
+    {
+        if (\is_array($values)) {
+            $values = implode(',', $values);
+        }
+        
+        $this->queryParams[$key] = $values;
+        
+        return $this;
+    }
 
     /**
      * @param array $options
@@ -93,6 +114,9 @@ class Client extends \GuzzleHttp\Client
         }
         if (null !== $this->filter) {
             $options[RequestOptions::QUERY]['filter'] = $this->filter;
+        }
+        if (null !== $this->queryParams) {
+            $options[RequestOptions::QUERY] = array_merge($options[RequestOptions::QUERY], $this->queryParams);
         }
 
         return $options;

--- a/src/Services/AbstractService.php
+++ b/src/Services/AbstractService.php
@@ -77,4 +77,16 @@ abstract class AbstractService
 
         return $this;
     }
+    
+    /**
+     * @param string $key
+     * @param $values
+     * @return $this
+     */
+    public function addQueryParam(string $key, $values)
+    {
+        $this->httpClient->addQueryParam($key, $values);
+        
+        return $this;
+    }
 }


### PR DESCRIPTION
#### Added
- Added possibility to pass custom query params.
For example:
```
$client->slates()->packets($slateId)->addQueryParam('sort', '-updated_at')->collection();
```
Related PR: https://github.com/airslateinc/slates-api/pull/202