### PR TITLE
[ABC-978] Slate addon file service

### DIFF
--- a/src/Entities/Addons/AddonFile.php
+++ b/src/Entities/Addons/AddonFile.php
@@ -5,6 +5,9 @@ namespace AirSlate\ApiClient\Entities\Addons;
 use AirSlate\ApiClient\Entities\BaseEntity;
 use AirSlate\ApiClient\Entities\EntityType;
 
+/**
+ * @deprecated
+ */
 class AddonFile extends BaseEntity
 {
     /**

--- a/src/Entities/Addons/SlateAddonFile.php
+++ b/src/Entities/Addons/SlateAddonFile.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace AirSlate\ApiClient\Entities\Addons;
+
+use AirSlate\ApiClient\Entities\BaseEntity;
+use AirSlate\ApiClient\Entities\EntityType;
+
+/**
+ * @property string id
+ * @property string name
+ * @property string size
+ * @property SlateAddon slateAddon
+ *
+ * @package AirSlate\ApiClient\Entities\Addons
+ */
+class SlateAddonFile extends BaseEntity
+{
+    /**
+     * @var string
+     */
+    protected $type = EntityType::SLATE_ADDON_FILE;
+
+    /**
+     * @return SlateAddon
+     */
+    public function getSlateAddon(): SlateAddon
+    {
+        return $this->hasOne(SlateAddon::class, 'slate_addon');
+    }
+}

--- a/src/Entities/EntityType.php
+++ b/src/Entities/EntityType.php
@@ -36,6 +36,7 @@ interface EntityType
     public const PACKET = 'packets';
     public const SLATE = 'slates';
     public const SLATE_ADDON = 'slate_addons';
+    public const SLATE_ADDON_FILE = 'slate_addon_files';
     public const SLATE_LINKS = 'slate_links';
     public const SLATE_INVITE = 'slate_invites';
     public const SLATE_DOCUMENT = 'slate_documents';

--- a/src/Models/SlateAddonFile/Upload.php
+++ b/src/Models/SlateAddonFile/Upload.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace AirSlate\ApiClient\Models\SlateAddonFile;
+
+use AirSlate\ApiClient\Entities\EntityType;
+use AirSlate\ApiClient\Models\AbstractModel;
+
+class Upload extends AbstractModel
+{
+    /**
+     * @var string
+     */
+    private $filename;
+
+    /**
+     * @var string
+     */
+    private $contents;
+
+    /**
+     * @var string
+     */
+    private $slateAddonUid;
+
+    /**
+     * @param string $filename
+     * @param string $contents
+     * @param string $slateAddonUid
+     */
+    public function __construct(string $filename, string $contents, string $slateAddonUid)
+    {
+        parent::__construct([]);
+        $this->filename = $filename;
+        $this->contents = $contents;
+        $this->slateAddonUid = $slateAddonUid;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setFilename(string $name): void
+    {
+        $this->filename = $name;
+    }
+
+    /**
+     * @param string $val
+     */
+    public function setContents(string $val): void
+    {
+        $this->contents = $val;
+    }
+
+    /**
+     * @param string $val
+     */
+    public function setSlateAddonUid(string $val): void
+    {
+        $this->slateAddonUid = $val;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'data' => [
+                'type' => EntityType::SLATE_ADDON_FILE,
+                'attributes' => [
+                    'filename' => $this->filename,
+                    'content' => $this->contents
+                ],
+                'relationships' => [
+                    'slate_addon' => [
+                        'data' => [
+                            'id' => $this->slateAddonUid,
+                            'type' => EntityType::SLATE_ADDON
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Factory method.
+     *
+     * @param string $filename
+     * @param string $contents
+     * @param string $slateAddonUid
+     * @return static
+     */
+    public static function make(string $filename, string $contents, string $slateAddonUid): self
+    {
+        return new static($filename, $contents, $slateAddonUid);
+    }
+}

--- a/src/Models/SlateAddonFile/Upload.php
+++ b/src/Models/SlateAddonFile/Upload.php
@@ -92,7 +92,7 @@ class Upload extends AbstractModel
      * @param string $slateAddonUid
      * @return static
      */
-    public static function make(string $filename, string $contents, string $slateAddonUid): self
+    public static function fromAttributes(string $filename, string $contents, string $slateAddonUid): self
     {
         return new static($filename, $contents, $slateAddonUid);
     }

--- a/src/Services/AddonFileService.php
+++ b/src/Services/AddonFileService.php
@@ -4,9 +4,13 @@ namespace AirSlate\ApiClient\Services;
 
 use AirSlate\ApiClient\Entities\Addons\AddonFile as AddonFileEntity;
 
+/**
+ * @deprecated
+ */
 class AddonFileService extends AbstractService
 {
     /**
+     * @deprecated
      * @param string $addonFileId
      * @return AddonFileEntity
      * @throws \Exception
@@ -23,6 +27,7 @@ class AddonFileService extends AbstractService
     }
 
     /**
+     * @deprecated
      * @param string $addonFileId
      * @return \Psr\Http\Message\StreamInterface
      */

--- a/src/Services/AddonFileService.php
+++ b/src/Services/AddonFileService.php
@@ -6,11 +6,13 @@ use AirSlate\ApiClient\Entities\Addons\AddonFile as AddonFileEntity;
 
 /**
  * @deprecated
+ * @see SlateAddonFileService
  */
 class AddonFileService extends AbstractService
 {
     /**
      * @deprecated
+     * @see SlateAddonFileService
      * @param string $addonFileId
      * @return AddonFileEntity
      * @throws \Exception
@@ -28,6 +30,7 @@ class AddonFileService extends AbstractService
 
     /**
      * @deprecated
+     * @see SlateAddonFileService
      * @param string $addonFileId
      * @return \Psr\Http\Message\StreamInterface
      */

--- a/src/Services/AddonsService.php
+++ b/src/Services/AddonsService.php
@@ -81,8 +81,9 @@ class AddonsService extends AbstractService
     {
         return new SlateAddonsService($this->httpClient);
     }
-    
+
     /**
+     * @deprecated
      * @return AddonFileService
      */
     public function addonFiles(): AddonFileService

--- a/src/Services/AddonsService.php
+++ b/src/Services/AddonsService.php
@@ -84,6 +84,7 @@ class AddonsService extends AbstractService
 
     /**
      * @deprecated
+     * @see SlateAddonFileService
      * @return AddonFileService
      */
     public function addonFiles(): AddonFileService

--- a/src/Services/SlateAddonFileService.php
+++ b/src/Services/SlateAddonFileService.php
@@ -17,7 +17,7 @@ class SlateAddonFileService extends AbstractService
      * @param string $slateAddonFileId
      * @return SlateAddonFile
      */
-    public function one(string $slateAddonFileId): SlateAddonFile
+    public function get(string $slateAddonFileId): SlateAddonFile
     {
         $url = $this->resolveEndpoint(sprintf('/slate-addon-files/%s', $slateAddonFileId));
 

--- a/src/Services/SlateAddonFileService.php
+++ b/src/Services/SlateAddonFileService.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace AirSlate\ApiClient\Services;
+
+use AirSlate\ApiClient\Entities\Addons\SlateAddonFile;
+use AirSlate\ApiClient\Models\SlateAddonFile\Upload;
+use GuzzleHttp\RequestOptions;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * @package AirSlate\ApiClient\Services
+ */
+class SlateAddonFileService extends AbstractService
+{
+    /**
+     * @param string $slateAddonFileId
+     * @return SlateAddonFile
+     */
+    public function one(string $slateAddonFileId): SlateAddonFile
+    {
+        $url = $this->resolveEndpoint(sprintf('/slate-addon-files/%s', $slateAddonFileId));
+
+        $response = $this->httpClient->get($url);
+
+        $content = \GuzzleHttp\json_decode($response->getBody(), true);
+
+        return SlateAddonFile::createFromOne($content);
+    }
+
+    /**
+     * @param string $slateAddonFileId
+     * @return StreamInterface
+     */
+    public function download(string $slateAddonFileId): StreamInterface
+    {
+        $url = $this->resolveEndpoint(sprintf('/slate-addon-files/%s/download', $slateAddonFileId));
+
+        return $this->httpClient->get($url)->getBody();
+    }
+
+    /**
+     * @param string $slateAddonFileId
+     */
+    public function delete(string $slateAddonFileId): void
+    {
+        $url = $this->resolveEndpoint(sprintf('/slate-addon-files/%s', $slateAddonFileId));
+
+        $this->httpClient->delete($url);
+    }
+
+    /**
+     * @param Upload $uploadIntent
+     * @return SlateAddonFile
+     */
+    public function upload(Upload $uploadIntent): SlateAddonFile
+    {
+        $url = $this->resolveEndpoint('/slate-addon-files');
+
+        $response = $this->httpClient->post($url, [
+            RequestOptions::JSON => $uploadIntent->toArray()
+        ]);
+
+        $content = \GuzzleHttp\json_decode($response->getBody(), true);
+
+        return SlateAddonFile::createFromOne($content);
+    }
+}

--- a/src/Services/SlateAddonsService.php
+++ b/src/Services/SlateAddonsService.php
@@ -11,6 +11,14 @@ use GuzzleHttp\RequestOptions;
 class SlateAddonsService extends AbstractService
 {
     /**
+     * @return SlateAddonFileService
+     */
+    public function slateAddonFiles(): SlateAddonFileService
+    {
+        return new SlateAddonFileService($this->httpClient);
+    }
+
+    /**
      * @param CreateSlateAddon $model
      * @return SlateAddon
      * @throws \Exception


### PR DESCRIPTION
- пометил все вещи связанные с addon-files как deprecated
- добавил новый сервис SlateAddonFileService для работы с новым ресурсом slate-addon-files
https://pdffiller.atlassian.net/browse/ABC-978

Локально тестировал каждый метод сервиса.