### PR TITLE
[AA-3430] BC: remove organizations relation

### DIFF
--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -14,21 +14,11 @@ namespace AirSlate\ApiClient\Entities;
  * @property string $created_at
  * @property string $updated_at
  *
- * @property-read Organization[] $organizations
  * @property-read Token $token
  */
 class User extends BaseEntity
 {
     protected $type = EntityType::USER;
-
-    /**
-     * @return array
-     * @throws \Exception
-     */
-    public function getOrganizations(): array
-    {
-        return $this->hasMany(Organization::class, 'organizations');
-    }
 
     /**
      * @return Token

--- a/src/Services/OrganizationsService.php
+++ b/src/Services/OrganizationsService.php
@@ -9,6 +9,7 @@ use AirSlate\ApiClient\Entities\Organization;
 use AirSlate\ApiClient\Exceptions\DomainException;
 use AirSlate\ApiClient\Models\Organization\Create;
 use AirSlate\ApiClient\Models\Organization\Update;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\RequestOptions;
 
 class OrganizationsService extends AbstractService
@@ -89,6 +90,21 @@ class OrganizationsService extends AbstractService
         $content = \GuzzleHttp\json_decode($response->getBody(), true);
 
         return Organization::createFromOne($content);
+    }
+
+    /**
+     * @param string $userUid
+     * @return array
+     * @throws GuzzleException
+     */
+    public function allByUser(string $userUid): array
+    {
+        $url = $this->resolveEndpoint("users/{$userUid}/organizations");
+        $response = $this->httpClient->get($url);
+
+        $content = \GuzzleHttp\json_decode($response->getBody(), true);
+
+        return Organization::createFromCollection($content);
     }
 
     /**


### PR DESCRIPTION
Backward compatibility break: organizations relations removed from User entity.

Clients should migrate to `\AirSlate\ApiClient\Services\OrganizationsService::allByUser` method

After the merge, the major version should be increased

refs: airslateinc/users-api#1209